### PR TITLE
Execute only for owners

### DIFF
--- a/wallet/wallet2.sol
+++ b/wallet/wallet2.sol
@@ -264,7 +264,7 @@ contract Wallet is multisig, multiowned, daylimit {
     // If not, goes into multisig process. We provide a hash on return to allow the sender to provide
     // shortcuts for the other confirmations (allowing them to avoid replicating the _to, _value
     // and _data arguments). They still get the option of using them if they want, anyways.
-    function execute(address _to, uint _value, bytes _data) external returns (bytes32 _r) {
+    function execute(address _to, uint _value, bytes _data) external onlyowner returns (bytes32 _r) {
         // first, take the opportunity to check that we're under the daily limit.
         if (underLimit(_value)) {
             SingleTransact(msg.sender, _value, _to, _data);


### PR DESCRIPTION
Without this change, requests are not really approved and no change is made to storage, but it is cleaner to have it. Furthermore, without this change, the execute function would return an operation hash instead of "0".