### PR TITLE
Address Set library

### DIFF
--- a/library_set/AddressSet.slb
+++ b/library_set/AddressSet.slb
@@ -1,0 +1,142 @@
+/// @title AddressMapper
+/// @author Andreas Olofsson (andreas1980@gmail.com)
+/// @dev AddressMapper is a set backed by an iterable map with (address, bool) entries.
+/// O(1) insert, find, and remove.
+/// Stores a boolean, and an array index (uint) for each element, in addition to the address.
+/// This is for easy lookup, and for making iteration possible.
+/// Order of insertion is not preserved.
+library AddressSet {
+
+    // Less annoying to use a boolean then having to worry about array indices etc.
+    struct Element {
+        uint valIndex;
+        bool exists;
+    }
+
+    struct Set
+    {
+        mapping(address => Element) data;
+        address[] values;
+        uint theSize;
+    }
+
+    /// @notice AddressSet.insert(set, address) to add a value to the set.
+    /// @dev Add values to the set.
+    /// @param set (AddressSet.Set) storage reference to the set.
+    /// @param val (address) the address
+    /// @return added (bool) true if the address was added, false if not (meaning the value already exists).
+    function insert(Set storage set, address val) returns (bool added)
+    {
+        if (set.data[val].exists){
+            return false;
+        } else {
+            var valIndex = set.values.length++;
+            set.data[val] = Element(valIndex, true);
+            set.values[valIndex] = val;
+            set.theSize++;
+            return true;
+        }
+    }
+
+    /// @notice AddressSet.remove(set, address) to remove a value from the set.
+    /// @dev Remove a value from the set.
+    /// @param set (AddressSet.Set) storage reference to the set.
+    /// @param val (address) the address
+    /// @return removed (bool) true if the address was removed, false if not (meaning the value wasn't found).
+    function remove(Set storage set, address val) returns (bool removed)
+    {
+        var elem = set.data[val];
+        if (!elem.exists){
+            return false;
+        }
+        var valIndex = elem.valIndex;
+        delete set.data[val];
+        var len = set.values.length;
+        if(valIndex != len - 1){
+            var swap = set.values[len - 1];
+            set.values[valIndex] = swap;
+            set.data[swap].valIndex = valIndex;
+        }
+        set.values.length--;
+        set.theSize--;
+        return true;
+    }
+
+    /// @notice AddressSet.removeAll(set) to remove all values from the set. NOTE: this might fail for large sets due to gas issues.
+    /// @dev Remove all values from the set.
+    /// @param set (AddressSet.Set) storage reference to the set.
+    /// @return numRemoved (uint) number of elements removed.
+    function removeAll(Set storage set) returns (uint numRemoved){
+        var l = set.values.length;
+        if(set.theSize == 0){
+            return 0;
+        }
+        for(uint i = 0; i < l; i++){
+            delete set.data[set.values[i]];
+        }
+        delete set.values;
+        set.theSize = 0;
+        return l;
+    }
+
+    /// @notice AddressSet.hasValue(set, address) to check if a value is contained in the set.
+    /// @dev Check if a value exists.
+    /// @param set (AddressSet.Set) storage reference to the set.
+    /// @param val (address) the address
+    /// @return has (bool) true if the address was found, false otherwise
+    function hasValue(Set storage set, address val) constant returns (bool has){
+        return set.data[val].exists;
+    }
+
+    /// @notice AddressSet.valueIndex(set, address) to get the values index in the backing array.
+    /// @dev Get values index in backing array.
+    /// @param set (AddressSet.Set) storage reference to the set.
+    /// @param val (address) the address
+    /// @return index (uint) the index
+    /// @return exists (bool) true if the element exists, false otherwise. Used because of index=0 ambiguity.
+    function valueIndex(Set storage set, address val) constant returns (uint index, bool exists){
+        var elem = set.data[val];
+        if(!elem.exists){
+            return;
+        }
+        index = elem.valIndex;
+        exists = true;
+        return;
+    }
+
+    /// @notice AddressSet.valueFromIndex(set, address) to get a value from backing array index. Useful when iterating.
+    /// @dev Get value from index in backing array.
+    /// @param set (AddressSet.Set) storage reference to the set.
+    /// @param index (uint) the address
+    /// @return index (uint) the index
+    /// @return exists (bool) true if the element exists, false otherwise. Used because of index=0 ambiguity.
+    function valueFromIndex(Set storage set, uint index) constant returns (address value, bool exists){
+        if(index >= set.values.length){
+            return;
+        }
+        value = set.values[index];
+        exists = true;
+        return;
+    }
+
+    /// @notice AddressSet.size(set) to get the size of the set.
+    /// @dev Get size of set.
+    /// @param set (AddressSet.Set) storage reference to the set.
+    /// @return size (uint) the size
+    function size(Set storage set) constant returns (uint size){
+        return set.theSize;
+    }
+
+    /// @notice AddressSet.values(set) to get all values in the set. NOTE: Amount of values may be high.
+    /// Will add values(set, startIndex, maxElements) when array slicing is supported.
+    /// Also you can't call this from other contracts since array is of dynamic size, and the size of
+    /// the return data is allocated before the actual call when done from a contract.
+    /// @dev Get values in set.
+    /// @param set (AddressSet.Set) storage reference to the set.
+    /// @return size (uint) the size
+    function values(Set storage set) constant returns (address[] vals){
+        vals = set.values;
+        return;
+    }
+
+}

--- a/library_set/AddressSetTest.sol
+++ b/library_set/AddressSetTest.sol
@@ -1,0 +1,145 @@
+contract AddressSetWrapper {
+
+    using AddressSet for AddressSet.Set;
+
+    AddressSet.Set _set;
+
+    function addAddress(address addr) returns (bool had) {
+        return _set.insert(addr);
+    }
+
+    function removeAddress(address addr) returns (bool removed) {
+        return _set.remove(addr);
+    }
+
+    function removeAllAddresses() returns (uint numRemoved) {
+        return _set.removeAll();
+    }
+
+    function hasAddress(address addr) constant returns (bool has) {
+        return _set.hasValue(addr);
+    }
+
+    function getAddressFromIndex(uint index) constant returns (address addr, bool has) {
+        return _set.valueFromIndex(index);
+    }
+
+    function getAddressKeyIndex(address addr) constant returns (uint index, bool exists) {
+        return _set.valueIndex(addr);
+    }
+
+    function numAddresses() constant returns (uint setSize) {
+        return _set.size();
+    }
+}
+
+contract AddressSetTest {
+
+    address constant TEST_ADDRESS = 0x12345;
+    address constant TEST_ADDRESS_2 = 0xABCDEF;
+    address constant TEST_ADDRESS_3 = 0xC0FFEE;
+
+    function testInsert() returns (bool has, bool atIndex0){
+        AddressSetWrapper asw = new AddressSetWrapper();
+        asw.addAddress(TEST_ADDRESS);
+        has = asw.hasAddress(TEST_ADDRESS);
+        var (a, e) = asw.getAddressFromIndex(0);
+        atIndex0 = e && a == TEST_ADDRESS;
+        return;
+    }
+
+    function testRemoveAddress() returns (bool removed, bool atIndex0IsNil, bool numAddressesIsNil){
+        AddressSetWrapper asw = new AddressSetWrapper();
+        asw.addAddress(TEST_ADDRESS);
+        asw.removeAddress(TEST_ADDRESS);
+        removed = !asw.hasAddress(TEST_ADDRESS);
+        var (a, e) = asw.getAddressFromIndex(0);
+        atIndex0IsNil = !e;
+        numAddressesIsNil = (asw.numAddresses() == 0);
+    }
+
+    function testAddTwoAddresses() returns (bool hasFirst, bool hasSecond, bool firstIsCorrect, bool secondIsCorrect, bool sizeIsCorrect){
+        AddressSetWrapper asw = new AddressSetWrapper();
+        asw.addAddress(TEST_ADDRESS);
+        asw.addAddress(TEST_ADDRESS_2);
+        hasFirst = asw.hasAddress(TEST_ADDRESS);
+        hasSecond = asw.hasAddress(TEST_ADDRESS_2);
+        var (a, e) = asw.getAddressFromIndex(0);
+        firstIsCorrect = e && a == TEST_ADDRESS;
+        (a, e) = asw.getAddressFromIndex(1);
+        secondIsCorrect = e && a == TEST_ADDRESS_2;
+
+        sizeIsCorrect = asw.numAddresses() == 2;
+    }
+
+    function testAddTwoAddressesRemoveLast() returns (bool hasFirst, bool secondRemoved, bool firstIsCorrect,
+                bool secondIsCorrect, bool sizeIsCorrect){
+        AddressSetWrapper asw = new AddressSetWrapper();
+        asw.addAddress(TEST_ADDRESS);
+        asw.addAddress(TEST_ADDRESS_2);
+        asw.removeAddress(TEST_ADDRESS_2);
+
+        hasFirst = asw.hasAddress(TEST_ADDRESS);
+        secondRemoved = !asw.hasAddress(TEST_ADDRESS_2);
+
+        var (a, e) = asw.getAddressFromIndex(0);
+        firstIsCorrect = e && a == TEST_ADDRESS;
+        (a, e) = asw.getAddressFromIndex(1);
+        secondIsCorrect = !e && a == 0;
+        sizeIsCorrect = asw.numAddresses() == 1;
+    }
+
+    function testAddTwoAddressesRemoveFirst() returns (bool firstRemoved, bool hasSecond, bool firstIsCorrect,
+                bool secondIsCorrect, bool sizeIsCorrect){
+        AddressSetWrapper asw = new AddressSetWrapper();
+        asw.addAddress(TEST_ADDRESS);
+        asw.addAddress(TEST_ADDRESS_2);
+        asw.removeAddress(TEST_ADDRESS);
+
+        firstRemoved = !asw.hasAddress(TEST_ADDRESS);
+        hasSecond = asw.hasAddress(TEST_ADDRESS_2);
+
+        var (a, e) = asw.getAddressFromIndex(0);
+        firstIsCorrect = e && a == TEST_ADDRESS_2;
+        (a, e) = asw.getAddressFromIndex(1);
+        secondIsCorrect = !e && a == 0;
+        sizeIsCorrect = asw.numAddresses() == 1;
+    }
+
+    function testAddThreeAddressesRemoveMiddle() returns (bool hasFirst, bool secondRemoved, bool hasThird,
+                bool firstIsCorrect, bool secondIsCorrect, bool sizeIsCorrect){
+        AddressSetWrapper asw = new AddressSetWrapper();
+        asw.addAddress(TEST_ADDRESS);
+        asw.addAddress(TEST_ADDRESS_2);
+        asw.addAddress(TEST_ADDRESS_3);
+        asw.removeAddress(TEST_ADDRESS_2);
+
+        hasFirst = asw.hasAddress(TEST_ADDRESS);
+        secondRemoved = !asw.hasAddress(TEST_ADDRESS_2);
+        hasThird = asw.hasAddress(TEST_ADDRESS_3);
+
+        var (a, e) = asw.getAddressFromIndex(0);
+        firstIsCorrect = e && a == TEST_ADDRESS;
+        (a, e) = asw.getAddressFromIndex(1);
+        secondIsCorrect = e && a == TEST_ADDRESS_3;
+        sizeIsCorrect = asw.numAddresses() == 2;
+    }
+
+    function testRemoveAllAddresses() returns (bool firstRemoved, bool secondRemoved, bool thirdRemoved,
+                bool sizeIsNil){
+        AddressSetWrapper asw = new AddressSetWrapper();
+        asw.addAddress(TEST_ADDRESS);
+        asw.addAddress(TEST_ADDRESS_2);
+        asw.addAddress(TEST_ADDRESS_3);
+        asw.removeAllAddresses();
+
+        firstRemoved = !asw.hasAddress(TEST_ADDRESS);
+        secondRemoved = !asw.hasAddress(TEST_ADDRESS_2);
+        thirdRemoved = !asw.hasAddress(TEST_ADDRESS_3);
+
+        sizeIsNil = asw.numAddresses() == 0;
+    }
+
+    // Can't test AddressSet.values since it returns a dynamically sized array.
+
+}

--- a/library_set/README.md
+++ b/library_set/README.md
@@ -1,0 +1,18 @@
+# AddressSet
+
+Simple address-set library with docs and tests. Based on the library/iterable_map. Uses many of the newer features such as tuples and library to type bindings.
+
+Iterating is possible by getting the size of the set then just call 'valueFromIndex' to get each value inside a loop. The entire set can be gotten only through an external call, as the set is backed by a dynamically sized array. That's a general (VM) issue btw, not specific to this library.
+
+### Test
+
+The simplest thing is to just run the test contract in browser-solidity. 
+
+1. Copy in the AddressSet library code first, then the two contracts in the test file.
+
+2. Click 'create' at the AddressSetTest contract in the side bar.
+
+3. Click each function. The return values should be true - but it's a bit difficult to see since they're all packed into one massive byte array. Should see some strategically placed 1's in there though. :D
+
+Tests serves as usage examples as well.
+


### PR DESCRIPTION
Very simple set implementation for addresses, based on `iterable_mapping`. Comes with a README, natspec docs and a unit-testing contract that can be run in browser solidity.