### PR TITLE
allow multisig for non value transfer

### DIFF
--- a/wallet/wallet.sol
+++ b/wallet/wallet.sol
@@ -262,7 +262,7 @@ contract daylimit is multiowned {
             m_lastDay = today();
         }
         // check to see if there's enough left - if so, subtract and return true.
-        if (m_spentToday + _value >= m_spentToday && m_spentToday + _value <= m_dailyLimit) {
+        if (m_spentToday + _value >= m_spentToday && m_spentToday + _value < m_dailyLimit) {
             m_spentToday += _value;
             return true;
         }


### PR DESCRIPTION
When using the multisig wallet for non value transfer purposes, it always requires only one signature since even with a daily limit of 0, a 0 value transfer transaction is "under the daily limit". 
Using `<` instead of  `<=` solves the problem.
The only downside is that the real daily limit which can be spend per day is `m_dailyLimit - 1 wei`.
