### PR TITLE
getOwner method to allow callers to get the owners on the wallet

### DIFF
--- a/wallet/wallet.sol
+++ b/wallet/wallet.sol
@@ -122,7 +122,12 @@ contract multiowned {
         clearPending();
         RequirementChanged(_newRequired);
     }
-    
+
+    // Gets an owner by 0-indexed position (using numOwners as the count)
+    function getOwner(uint ownerIndex) external constant returns (address) {
+        return address(m_owners[ownerIndex + 1]);
+    }
+
     function isOwner(address _addr) returns (bool) {
         return m_ownerIndex[uint(_addr)] > 0;
     }
@@ -270,8 +275,8 @@ contract daylimit is multiowned {
 	// FIELDS
 
     uint public m_dailyLimit;
-    uint m_spentToday;
-    uint m_lastDay;
+    uint public m_spentToday;
+    uint public m_lastDay;
 }
 
 // interface contract for multisig proxy contracts; see below for docs.


### PR DESCRIPTION
Expose the getOwner method, which allows for callers to get the owners of the wallet. 
Because solidity cannot return arrays, the caller can get the total list of owners by calling m_numOwners first and then iterating on getOwner from 0 to m_numOwners (0-indexed). 

Example usage in tests:
https://github.com/BitGo/eth-multisig-v2/blob/master/test/wallet.js#L41

This change also exposes m_spentToday and m_lastDay as public fields. 