### PR TITLE
Is execute not transact.

### DIFF
--- a/wallet/wallet.sol
+++ b/wallet/wallet.sol
@@ -304,7 +304,7 @@ contract multisig {
 }
 
 // usage:
-// bytes32 h = Wallet(w).from(oneOwner).transact(to, value, data);
+// bytes32 h = Wallet(w).from(oneOwner).execute(to, value, data);
 // Wallet(w).from(anotherOwner).confirm(h);
 contract Wallet is multisig, multiowned, daylimit {
 


### PR DESCRIPTION
The Wallet contract already change the function name from "transact" to "execute“
It's a typo in comment.