### PR TITLE
Don't allow instant withdrawals if the daily limit it 0

### DIFF
--- a/wallet/wallet.sol
+++ b/wallet/wallet.sol
@@ -260,6 +260,11 @@ contract daylimit is multiowned {
     // checks to see if there is at least `_value` left from the daily limit today. if there is, subtracts it and
     // returns true. otherwise just returns false.
     function underLimit(uint _value) internal onlyowner returns (bool) {
+        // Don't allow any instant withdrawals if the daily limit is 0
+        if (m_dailyLimit == 0) {
+           return false;
+        }
+
         // reset the spend limit if we're on a different day to last time.
         if (today() > m_lastDay) {
             m_spentToday = 0;


### PR DESCRIPTION
Before this change, even if the daily limit was 0, token withdrawals
would by-pass the multi-sig capabilities of this wallet. While this
is still by-passed if there is a dailyLimit set, at least if it is 0
you require multi-sig as configured.