### PR TITLE
Add remove function success return value

### DIFF
--- a/library/iterable_mapping.sol
+++ b/library/iterable_mapping.sol
@@ -32,6 +32,7 @@ library IterableMapping
     delete self.data[key];
     self.keys[keyIndex - 1].deleted = true;
     self.size --;
+    return true;
   }
   function contains(itmap storage self, uint key) returns (bool)
   {


### PR DESCRIPTION
Due to the bool initial value is `false`, the `success` value need to be set `true` after remove data.